### PR TITLE
Change "arturo" to sys\binary

### DIFF
--- a/unitt.art
+++ b/unitt.art
@@ -18,7 +18,7 @@ runTests: $[testPath :string][
 
     loop testfiles 'file [ 
         print ~"\n===== |file| =====\n"
-        result: execute.code ~"arturo |file|"
+        result: execute.code ~"|sys\binary| |file|"
 
         output: split.lines result\output
 


### PR DESCRIPTION
This is an interesting trick:

basically, it will run the tests with the exact same binary that is running `unitt.art` or the module itself.

This is very useful in case the binary is a) not `--install`ed, b) has a different name (I do it all the time with `--as` to check different changes 😉 )