### PR TITLE
Feature: implement skippable tests

### DIFF
--- a/tests/testDefault/sample
+++ b/tests/testDefault/sample
@@ -103,8 +103,8 @@
 
 ⏏️    TOTAL: 24 assertions
 ✅  PASSED: 20 assertions
-❌  FAILED: 4 assertions
 ⏩ SKIPPED: 4 assertions
+❌  FAILED: 4 assertions
 
 ===== ========== =====
 

--- a/tests/testDefault/sample
+++ b/tests/testDefault/sample
@@ -4,6 +4,12 @@
 [0;33m✅ - assert that are equal[0m 
      assertion : [1 = code\fun]
 
+[0;33m✅ - assert that are equal[0m 
+     assertion : [1 = code\fun]
+
+[0;33m⏩ - assert that are equal[0m 
+     skipped! 
+
 [0;33m✅ - assert that are different[0m 
      assertion : [2 <> code\fun]
 
@@ -22,6 +28,12 @@
 
 [0;33m✅ - assert that are equal[0m 
      assertion : [1 = code\fun]
+
+[0;33m✅ - assert that are equal[0m 
+     assertion : [1 = code\fun]
+
+[0;33m⏩ - assert that are equal[0m 
+     skipped! 
 
 [0;33m✅ - assert that are different[0m 
      assertion : [2 <> code\fun]
@@ -42,6 +54,12 @@
 [0;33m✅ - assert that are equal[0m 
      assertion : [1 = code\fun]
 
+[0;33m✅ - assert that are equal[0m 
+     assertion : [1 = code\fun]
+
+[0;33m⏩ - assert that are equal[0m 
+     skipped! 
+
 [0;33m✅ - assert that are different[0m 
      assertion : [2 <> code\fun]
 
@@ -61,6 +79,12 @@
 [0;33m✅ - assert that are equal[0m 
      assertion : [1 = code\fun]
 
+[0;33m✅ - assert that are equal[0m 
+     assertion : [1 = code\fun]
+
+[0;33m⏩ - assert that are equal[0m 
+     skipped! 
+
 [0;33m✅ - assert that are different[0m 
      assertion : [2 <> code\fun]
 
@@ -77,9 +101,10 @@
 
 ===== Statistics =====
 
-⏏️  TOTAL:  20 assertions
-✅ PASSED: 16 assertions
-❌ FAILED: 4 assertions
+⏏️    TOTAL: 24 assertions
+✅  PASSED: 20 assertions
+❌  FAILED: 4 assertions
+⏩ SKIPPED: 4 assertions
 
 ===== ========== =====
 

--- a/tests/testDefault/test/a/test1.art
+++ b/tests/testDefault/test/a/test1.art
@@ -3,9 +3,21 @@ unitt: import.lean {unitt}
 
 do ::
 
+unix?: false
+win?: true
+
 unitt\test "are equal" [
     assert -> 1 = code\fun
 ]
+
+unitt\test.skip: unix? "are equal" [
+    assert -> 1 = code\fun
+]
+
+unitt\test.skip: win? "are equal" [
+    assert -> 1 = code\fun
+]
+
 
 unitt\test "are different" [
     assert -> 2 <> code\fun

--- a/tests/testDefault/test/a/test2.art
+++ b/tests/testDefault/test/a/test2.art
@@ -3,9 +3,21 @@ unitt: import.lean {unitt}
 
 do ::
 
+unix?: false
+win?: true
+
 unitt\test "are equal" [
     assert -> 1 = code\fun
 ]
+
+unitt\test.skip: unix? "are equal" [
+    assert -> 1 = code\fun
+]
+
+unitt\test.skip: win? "are equal" [
+    assert -> 1 = code\fun
+]
+
 
 unitt\test "are different" [
     assert -> 2 <> code\fun

--- a/tests/testDefault/test/other.art
+++ b/tests/testDefault/test/other.art
@@ -3,9 +3,21 @@ unitt: import.lean {unitt}
 
 do ::
 
+unix?: false
+win?: true
+
 unitt\test "are equal" [
     assert -> 1 = code\fun
 ]
+
+unitt\test.skip: unix? "are equal" [
+    assert -> 1 = code\fun
+]
+
+unitt\test.skip: win? "are equal" [
+    assert -> 1 = code\fun
+]
+
 
 unitt\test "are different" [
     assert -> 2 <> code\fun

--- a/tests/testDefault/test/test1.art
+++ b/tests/testDefault/test/test1.art
@@ -3,7 +3,18 @@ unitt: import.lean {unitt}
 
 do ::
 
+unix?: false
+win?: true
+
 unitt\test "are equal" [
+    assert -> 1 = code\fun
+]
+
+unitt\test.skip: unix? "are equal" [
+    assert -> 1 = code\fun
+]
+
+unitt\test.skip: win? "are equal" [
     assert -> 1 = code\fun
 ]
 

--- a/tests/testDefault/test/test2.art
+++ b/tests/testDefault/test/test2.art
@@ -3,9 +3,21 @@ unitt: import.lean {unitt}
 
 do ::
 
+unix?: false
+win?: true
+
 unitt\test "are equal" [
     assert -> 1 = code\fun
 ]
+
+unitt\test.skip: unix? "are equal" [
+    assert -> 1 = code\fun
+]
+
+unitt\test.skip: win? "are equal" [
+    assert -> 1 = code\fun
+]
+
 
 unitt\test "are different" [
     assert -> 2 <> code\fun

--- a/unitt.art
+++ b/unitt.art
@@ -65,8 +65,8 @@ runTests: $[testPath :string][
     print ~"\n===== Statistics =====\n"
     print ~"⏏️    TOTAL: |passed + failed| assertions"
     print ~"✅  PASSED: |passed| assertions"
-    print ~"❌  FAILED: |failed| assertions"
     print ~"⏩ SKIPPED: |skipped| assertions"
+    print ~"❌  FAILED: |failed| assertions"
     print ~"\n===== ========== =====\n"
 
     if or? (fatalError) (failed > 0) 

--- a/unitt.art
+++ b/unitt.art
@@ -24,6 +24,7 @@ runTests: $[testPath :string][
     ; Important to final statistics
     passed: 0
     failed: 0
+    skipped: 0
 
     ; Important to return error code.
     ; If some test throw an error and don't explicitly catches it,
@@ -52,6 +53,7 @@ runTests: $[testPath :string][
             print line
             if in? '✅' line -> inc 'passed
             if in? '❌' line -> inc 'failed
+            if in? '⏩' line -> inc 'skipped
         ]
 
         ; if some test throws an error
@@ -61,9 +63,10 @@ runTests: $[testPath :string][
     ]
 
     print ~"\n===== Statistics =====\n"
-    print ~"⏏️  TOTAL:  |passed + failed| assertions"
-    print ~"✅ PASSED: |passed| assertions"
-    print ~"❌ FAILED: |failed| assertions"
+    print ~"⏏️    TOTAL: |passed + failed| assertions"
+    print ~"✅  PASSED: |passed| assertions"
+    print ~"❌  FAILED: |failed| assertions"
+    print ~"⏩ SKIPPED: |skipped| assertions"
     print ~"\n===== ========== =====\n"
 
     if or? (fatalError) (failed > 0) 

--- a/unitt.art
+++ b/unitt.art
@@ -130,7 +130,10 @@ test: $[description :string testCase :block][
 
         passBlock: -> print [color #yellow ~"✅ |template|"]
         failBlock: -> print [color #yellow ~"❌ |template|"]
-        skipBlock: -> print [color #yellow ~"⏩ |template|"]
+        skipBlock: [ 
+            print [color #yellow ~"⏩ |template|"]
+            print "     skipped! \n"
+        ]
 
         (skip?)? -> do skipBlock [
             (do condition)? 

--- a/unitt.art
+++ b/unitt.art
@@ -109,28 +109,36 @@ test: $[description :string testCase :block][
     ;;          test.skip: unix? "split is working for windows's paths" [
     ;;              assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
     ;;          ]
+    ;;          ; # running on Windows:
     ;;          ; ✅ - assert that split is working for windows's paths 
     ;;          ; assertion : [[. splited path] = split path .\splited\path]
+    ;;          ; 
+    ;;          ; # running on Unix:
+    ;;          ; ⏩ - assert that split is working for windows's paths 
+    ;;          ; 
     ;; }
 
     sep: (attr 'prop)? -> "~" -> "-"
     template: ~"|sep| assert that |description|"
 
+    skip?: attr 'skip
+
     assert: $[condition :block][
 
         passBlock: -> print [color #yellow ~"✅ |template|"]
         failBlock: -> print [color #yellow ~"❌ |template|"]
+        skipBlock: -> print [color #yellow ~"⏩ |template|"]
 
-        (do condition)? 
-            passBlock
-            failBlock
+        (skip?)? -> do skipBlock [
+            (do condition)? 
+                passBlock
+                failBlock
 
-        print ~"     assertion : |condition|\n"
+            print ~"     assertion : |condition|\n"
+        ]
     ]
 
-    if not? attr 'skip [
-        do testCase
-    ]
+    do testCase
 
 ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -84,7 +84,7 @@ test: $[description :string testCase :block][
     ;; ]
     ;; options: [
     ;;      prop: :logical « defines if a test is property-based
-    ;;      disable: :logical « skip test if true
+    ;;      skip: :logical « skip test if true
     ;; ]
     ;;
     ;; note: « `assert` is injected, and only available inside the `test`'s block.
@@ -106,7 +106,7 @@ test: $[description :string testCase :block][
     ;;          ; ✅ ~ assert that appending with keyword or operator has the same behavior 
     ;;          ; assertion : [[append b a] = [b ++ a]]
     ;;          
-    ;;          test.disable: unix? "split is working for windows's paths" [
+    ;;          test.skip: unix? "split is working for windows's paths" [
     ;;              assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
     ;;          ]
     ;;          ; ✅ - assert that split is working for windows's paths 
@@ -128,7 +128,7 @@ test: $[description :string testCase :block][
         print ~"     assertion : |condition|\n"
     ]
 
-    if not? attr 'disable [
+    if not? attr 'skip [
         do testCase
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -84,6 +84,7 @@ test: $[description :string testCase :block][
     ;; ]
     ;; options: [
     ;;      prop: :logical « defines if a test is property-based
+    ;;      disable: :logical « skip test if true
     ;; ]
     ;;
     ;; note: « `assert` is injected, and only available inside the `test`'s block.
@@ -104,7 +105,12 @@ test: $[description :string testCase :block][
     ;;          ;
     ;;          ; ✅ ~ assert that appending with keyword or operator has the same behavior 
     ;;          ; assertion : [[append b a] = [b ++ a]]
-    ;;          ;
+    ;;          
+    ;;          test.disable: unix? "split is working for windows's paths" [
+    ;;              assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
+    ;;          ]
+    ;;          ; ✅ - assert that split is working for windows's paths 
+    ;;          ; assertion : [[. splited path] = split path .\splited\path]
     ;; }
 
     sep: (attr 'prop)? -> "~" -> "-"
@@ -122,7 +128,9 @@ test: $[description :string testCase :block][
         print ~"     assertion : |condition|\n"
     ]
 
-    do testCase
+    if not? attr 'disable [
+        do testCase
+    ]
 
 ]
 


### PR DESCRIPTION
## Adding skippable tests

### At a Glance

_Code_:
```art
test.skip: unix? "split is working for windows's paths" [
    assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
]
```

_Running on Windows_:
```
✅ - assert that split is working for windows's paths 
      assertion : [[. splited path] = split path .\splited\path]
```
_Running on Unix_:

```
⏩ - assert that split is working for windows's paths      
      skipped!
```

### Explanation

**The tests**

That is basically the most common way of using this feature. Simple and easy.
The user can determine when this should not be run at runtime, in a flexible way.
Just do whatever you want.

You can also just disable a test using `.skip` (as an `:attribute` instead of `:attributeLabel`), so your test will always be skipped until you remove this.

**The tester**

Also, skipped tests goes to the _tester_'s statistics. This is the new look:

```
===== Statistics =====

⏏️   TOTAL: 24 assertions
✅  PASSED: 20 assertions
⏩ SKIPPED: 4 assertions
❌  FAILED: 4 assertions

===== ========== =====
```

## Original Propose

* The original propose can be found here: #2

**Accepted Ideas**

* Make it skippable, 🙂.
* Use the `skip` attribute.

**Rejected Ideas**:

* Usage of CLI parsing
  * A simpler `:logical` is better for this case, more flexible and delegates what to do to the user.
  * This is simpler because won't mess `args`, and won't introduce bugs. `KISS` (Keep It Simple Stupid).
* `.when` and `.only` attributes.
  * Again `KISS`, there is no reason to do this.

**Beyond Ideas**:

* Put skipped tests into statistics
* Make `.skip`'s value optional, so you can just disable your test.

---
* Closes #2