### PR TITLE
Feature: add tests grouping

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,13 @@ so that is great if you're working with *Continuous Integration*.
     A function that is only available inside the `test` case,
     makes an assertion given the `condition`.
 
+
+> [!WARNING]
+> Never import this lib as `.lean`, or this will break the current code.
+> This happens due to the nature of Arturo (being concatenative), 
+> and the way we importings are working right now.
+> This may change in future.
+
 ---
 
 > Background photo on ["At a Glance"](#at-a-glance) 

--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,8 @@ so that is great if you're working with *Continuous Integration*.
 - `assert: $[condition :block]`:
     A function that is only available inside the `test` case,
     makes an assertion given the `condition`.
+- `suite: $[description :string tests :block]`:
+    Visually groups tests together.
 
 
 > [!WARNING]

--- a/test.sh
+++ b/test.sh
@@ -68,3 +68,23 @@ diff --brief sample output ||           \
 rm unitt.art
 rm output
 cd ../..
+
+# ========== Running the test suite ========== #
+
+echo "Testing the test grouping via suite"
+
+# copying unitt to tests
+
+cp unitt.art tests/test-suite
+cd tests/test-suite
+
+# testing assertions
+./suite.test.art > output 
+
+diff --brief sample output ||           \
+    diff --side-by-side sample output
+
+# cleaning test
+rm unitt.art
+rm output
+cd ../..

--- a/tests/test-suite/sample
+++ b/tests/test-suite/sample
@@ -1,0 +1,20 @@
+[0;33m✅ - assert that I'm not indented[0m 
+     assertion : [true]
+
+Suite: Indenting tests 
+ 
+[0;33m    ✅ - assert that I'm indented[0m 
+         assertion : [true]
+
+[0;33m    ⏩ - assert that I'm indented[0m 
+         skipped! 
+
+[0;33m    ❌ - assert that I'm indented[0m 
+         assertion : [false]
+
+[0;33m⏩ - assert that I'm not indented[0m 
+     skipped! 
+
+[0;33m❌ - assert that I'm not indented[0m 
+     assertion : [false]
+

--- a/tests/test-suite/suite.test.art
+++ b/tests/test-suite/suite.test.art
@@ -1,0 +1,31 @@
+#! arturo
+
+import {unitt}!
+
+test "I'm not indented" [
+    assert -> true
+]
+
+suite "Indenting tests" [
+
+    test "I'm indented" [
+        assert -> true
+    ]
+
+    test.skip "I'm indented" [
+        assert -> true
+    ]
+
+    test "I'm indented" [
+        assert -> false
+    ]
+
+]
+
+test.skip "I'm not indented" [
+    assert -> false
+]
+
+test "I'm not indented" [
+    assert -> false
+]

--- a/unitt.art
+++ b/unitt.art
@@ -93,18 +93,6 @@ runTests: $[testPath :string][
 
 ]
 
-; TODO: Solve acessing `__testIndent` from imports
-;
-; Right now, if you import `unitt` scopeless, this will work well.
-; But, by importing this with `.lean` attribute, this won't work.
-;
-; The reson is, modules are imported as dict-like objects, so,
-; `__testIndent` is actually `unitt\__testIndent` when imported with `.lean`. 
-; Internally our functions are calling `__testIndent`, that will not exist
-; if imported with `.lean`. The same is true for the inverse.
-; So, there is no silver bullet.
-;
-; This feature will be here only here, until I actually solve this.
 __testIndent: ""
 
 suite: $[description :string tests :block][

--- a/unitt.art
+++ b/unitt.art
@@ -94,23 +94,23 @@ runTests: $[testPath :string][
 
 ]
 
-; TODO: Solve acessing `__testIdent` from imports
+; TODO: Solve acessing `__testIndent` from imports
 ;
 ; Right now, if you import `unitt` scopeless, this will work well.
 ; But, by importing this with `.lean` attribute, this won't work.
 ;
 ; The reson is, modules are imported as dict-like objects, so,
-; `__testIdent` is actually `unitt\__testIdent` when imported with `.lean`. 
-; Internally our functions are calling `__testIdent`, that will not exist
+; `__testIndent` is actually `unitt\__testIndent` when imported with `.lean`. 
+; Internally our functions are calling `__testIndent`, that will not exist
 ; if imported with `.lean`. The same is true for the inverse.
 ; So, there is no silver bullet.
 ;
 ; This feature will be here only here, until I actually solve this.
-__testIdent: ""
+__testIndent: ""
 
 suite: $[description :string tests :block][
     print ["Suite:" description "\n"]
-    __testIdent: "    "
+    __testIndent: "    "
     do tests
 ]
 
@@ -169,11 +169,11 @@ test: $[description :string testCase :block][
 
     assert: $[condition :block][
 
-        passBlock: -> print [color #yellow ~"|__testIdent|✅ |template|"]
-        failBlock: -> print [color #yellow ~"|__testIdent|❌ |template|"]
+        passBlock: -> print [color #yellow ~"|__testIndent|✅ |template|"]
+        failBlock: -> print [color #yellow ~"|__testIndent|❌ |template|"]
         skipBlock: [ 
-            print [color #yellow ~"|__testIdent|⏩ |template|"]
-            print ~"|__testIdent|     skipped! \n"
+            print [color #yellow ~"|__testIndent|⏩ |template|"]
+            print ~"|__testIndent|     skipped! \n"
         ]
 
         (skip?)? -> do skipBlock [
@@ -181,7 +181,7 @@ test: $[description :string testCase :block][
                 passBlock
                 failBlock
 
-            print ~"|__testIdent|     assertion : |condition|\n"
+            print ~"|__testIndent|     assertion : |condition|\n"
         ]
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -161,7 +161,7 @@ test: $[description :string testCase :block][
         failBlock: -> print [color #yellow ~"|__testIdent|❌ |template|"]
         skipBlock: [ 
             print [color #yellow ~"|__testIdent|⏩ |template|"]
-            print "     skipped! \n"
+            print ~"|__testIdent|     skipped! \n"
         ]
 
         (skip?)? -> do skipBlock [
@@ -169,7 +169,7 @@ test: $[description :string testCase :block][
                 passBlock
                 failBlock
 
-            print [__testIdent ~"     assertion : |condition|\n"]
+            print ~"|__testIdent|     assertion : |condition|\n"
         ]
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -94,6 +94,15 @@ runTests: $[testPath :string][
 
 ]
 
+__testIdent: ""
+
+suite: $[description :string tests :block][
+    print ["Suite:" description "\n"]
+    __testIdent: "    "
+    do tests
+]
+
+
 test: $[description :string testCase :block][
     ;; description: {
     ;;    Run an unit-test, printing it's result.
@@ -148,10 +157,10 @@ test: $[description :string testCase :block][
 
     assert: $[condition :block][
 
-        passBlock: -> print [color #yellow ~"✅ |template|"]
-        failBlock: -> print [color #yellow ~"❌ |template|"]
+        passBlock: -> print [color #yellow ~"|__testIdent|✅ |template|"]
+        failBlock: -> print [color #yellow ~"|__testIdent|❌ |template|"]
         skipBlock: [ 
-            print [color #yellow ~"⏩ |template|"]
+            print [color #yellow ~"|__testIdent|⏩ |template|"]
             print "     skipped! \n"
         ]
 
@@ -160,7 +169,7 @@ test: $[description :string testCase :block][
                 passBlock
                 failBlock
 
-            print ~"     assertion : |condition|\n"
+            print [__testIdent ~"     assertion : |condition|\n"]
         ]
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -4,6 +4,11 @@
 ;; version: 0.1.1
 ;; repository: « https://github.com/RickBarretto/unitt
 ;;
+;; warning: {
+;;    Never import this as lean, or this will break the whole code.
+;;    At least, for now. This may change in future updates.
+;; }
+;;
 ;; export: ['runTests 'test]
 
 runTests: $[testPath :string][

--- a/unitt.art
+++ b/unitt.art
@@ -94,6 +94,18 @@ runTests: $[testPath :string][
 
 ]
 
+; TODO: Solve acessing `__testIdent` from imports
+;
+; Right now, if you import `unitt` scopeless, this will work well.
+; But, by importing this with `.lean` attribute, this won't work.
+;
+; The reson is, modules are imported as dict-like objects, so,
+; `__testIdent` is actually `unitt\__testIdent` when imported with `.lean`. 
+; Internally our functions are calling `__testIdent`, that will not exist
+; if imported with `.lean`. The same is true for the inverse.
+; So, there is no silver bullet.
+;
+; This feature will be here only here, until I actually solve this.
 __testIdent: ""
 
 suite: $[description :string tests :block][

--- a/unitt.art
+++ b/unitt.art
@@ -93,11 +93,11 @@ runTests: $[testPath :string][
 
 ]
 
-__testIndent: ""
+_unittTestsIndentation: ""
 
 suite: $[description :string tests :block][
     print ["Suite:" description "\n"]
-    __testIndent: "    "
+    _unittTestsIndentation: "    "
     do tests
 ]
 
@@ -156,11 +156,11 @@ test: $[description :string testCase :block][
 
     assert: $[condition :block][
 
-        passBlock: -> print [color #yellow ~"|__testIndent|✅ |template|"]
-        failBlock: -> print [color #yellow ~"|__testIndent|❌ |template|"]
+        passBlock: -> print [color #yellow ~"|_unittTestsIndentation|✅ |template|"]
+        failBlock: -> print [color #yellow ~"|_unittTestsIndentation|❌ |template|"]
         skipBlock: [ 
-            print [color #yellow ~"|__testIndent|⏩ |template|"]
-            print ~"|__testIndent|     skipped! \n"
+            print [color #yellow ~"|_unittTestsIndentation|⏩ |template|"]
+            print ~"|_unittTestsIndentation|     skipped! \n"
         ]
 
         (skip?)? -> do skipBlock [
@@ -168,7 +168,7 @@ test: $[description :string testCase :block][
                 passBlock
                 failBlock
 
-            print ~"|__testIndent|     assertion : |condition|\n"
+            print ~"|_unittTestsIndentation|     assertion : |condition|\n"
         ]
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -101,6 +101,41 @@ runTests: $[testPath :string][
 _unittTestsIndentation: ""
 
 suite: $[description :string tests :block][
+    ;; description: « Visually groups tests.
+    ;;
+    ;; arguments: [
+    ;;      description: « the suite description
+    ;;      test: « the block containing the tests statements
+    ;; ]
+    ;; options: [
+    ;;      prop: :logical « defines if a test is property-based
+    ;;      skip: :logical « skip test if true
+    ;; ]
+    ;;
+    ;; example: {
+    ;;      ; testAppend.art
+    ;;      import {unitt}!
+    ;;      
+    ;;      suite "Groups some tests together" [
+    ;;
+    ;;          test.prop "appending with keyword or operator has the same behavior" [
+    ;;              a: [a b c d e f g]
+    ;;              b: [h i j k l m n]
+    ;;              assert -> (append a b) = (a ++ b)
+    ;;          ]
+    ;;          
+    ;;          test.skip: unix? "split is working for windows's paths" [
+    ;;              assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
+    ;;          ]
+    ;;      ]
+    ;;      ; Suite: Groups some tests together
+    ;;      ;
+    ;;      ;     ✅ ~ assert that appending with keyword or operator has the same behavior 
+    ;;      ;     assertion : [[append a b] = [a ++ b]]
+    ;;      ;
+    ;;      ;     ✅ - assert that split is working for windows's paths 
+    ;;      ;     assertion : [[. splited path] = split path .\splited\path]
+    ;; }
     print ["Suite:" description "\n"]
     _unittTestsIndentation: "    "
     do tests

--- a/unitt.art
+++ b/unitt.art
@@ -125,28 +125,28 @@ test: $[description :string testCase :block][
     ;;      import {unitt}!
     ;;      
     ;;      
-    ;;          test.prop "appending with keyword or operator has the same behavior" [
-    ;;              a: [a b c d e f g]
-    ;;              b: [h i j k l m n]
-    ;;              assert -> (append a b) = (a ++ b)
-    ;;              assert -> (append b a) = (b ++ a)
-    ;;          ]
-    ;;          ; ✅ ~ assert that appending with keyword or operator has the same behavior 
-    ;;          ; assertion : [[append a b] = [a ++ b]]
-    ;;          ;
-    ;;          ; ✅ ~ assert that appending with keyword or operator has the same behavior 
-    ;;          ; assertion : [[append b a] = [b ++ a]]
+    ;;      test.prop "appending with keyword or operator has the same behavior" [
+    ;;          a: [a b c d e f g]
+    ;;          b: [h i j k l m n]
+    ;;          assert -> (append a b) = (a ++ b)
+    ;;          assert -> (append b a) = (b ++ a)
+    ;;      ]
+    ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
+    ;;      ; assertion : [[append a b] = [a ++ b]]
+    ;;      ;
+    ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
+    ;;      ; assertion : [[append b a] = [b ++ a]]
     ;;          
-    ;;          test.skip: unix? "split is working for windows's paths" [
-    ;;              assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
-    ;;          ]
-    ;;          ; # running on Windows:
-    ;;          ; ✅ - assert that split is working for windows's paths 
-    ;;          ; assertion : [[. splited path] = split path .\splited\path]
-    ;;          ; 
-    ;;          ; # running on Unix:
-    ;;          ; ⏩ - assert that split is working for windows's paths 
-    ;;          ; 
+    ;;      test.skip: unix? "split is working for windows's paths" [
+    ;;          assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
+    ;;      ]
+    ;;      ; # running on Windows:
+    ;;      ; ✅ - assert that split is working for windows's paths 
+    ;;      ; assertion : [[. splited path] = split path .\splited\path]
+    ;;      ; 
+    ;;      ; # running on Unix:
+    ;;      ; ⏩ - assert that split is working for windows's paths 
+    ;;      ; 
     ;; }
 
     sep: (attr 'prop)? -> "~" -> "-"


### PR DESCRIPTION
## Implement the `suite` function

### At a Glance

```art
suite "Grouping some tests" [

    test "I'm indented and I'll pass" [
        assert -> true
    ]

    test.skip "I'm indented and I'll skip" [
        assert -> true
    ]

    test "I'm indented and I'll fail" [
        assert -> false
    ]

]
```

Output:

```
Suite: Grouping some tests

    ✅ - assert that I'm indented and I'll pass
         assertion : [true]

    ⏩ - assert that I'm indented and I'll skip
         skipped!

    ❌ - assert that I'm indented and I'll fail
         assertion : [false]
```

### Explanation

Right now, the indentation is done via `__testIndent` variable. So, what `suite` does is printing the header and modify that variable for its scope and only for its scope.

### Drawbacks

Unfortunately, considering the way arturo's modules works, I can't call functions or variables internally.

Here comes the complete explanation:

Basically, every module when imported with the `.lean` attribute is imported as a `:dicttionary`-like object, this means that when I try to call `__testIndent` I'm trying to find `__testIndent`, but this does not exist in the caller module, since this identifier is now `<dict>\__testIndent`, so if you imported `unitt` as `unitt`: `unitt\__testIndent`.

Basically, there is no silver bullet here. ~So, I'll keep this feature locked in this PR until I know what to do.~

~I can't merge or release it with this kind of drawback.~

I decided to deprecate `.lean` imports for while. :wink:

## Original Propose

* The original propose can be found here: #7

---

* Closes #7 
* See #17