### PR TITLE
Deprecate lean importing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,10 +60,9 @@ tester.art
 Into your `tester.art`, you must:
 
 ```art
-import {unitt}
+import {unitt}!
 
-do ::
-    runTests "tests"
+runTests "tests"
 ```
 
 To run it, call:

--- a/tests/test-default/sample
+++ b/tests/test-default/sample
@@ -109,6 +109,6 @@
 ===== ========== =====
 
 [1;31m>> Program |[0m [1;90mFile: [0m[0;90mtester.art
-[1;31m     error |[0m [1;90mLine: [0m[0;90m92[0m
+[1;31m     error |[0m [1;90mLine: [0m[0;90m91[0m
            [1;31m|[0m 
            [1;31m|[0m Some tests failed!

--- a/tests/test-default/test/a/test1.art
+++ b/tests/test-default/test/a/test1.art
@@ -1,33 +1,33 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
 unix?: false
 win?: true
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: unix? "are equal" [
+test.skip: unix? "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: win? "are equal" [
+test.skip: win? "are equal" [
     assert -> 1 = code\fun
 ]
 
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-default/test/a/test1.art
+++ b/tests/test-default/test/a/test1.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 unix?: false
 win?: true

--- a/tests/test-default/test/a/test2.art
+++ b/tests/test-default/test/a/test2.art
@@ -1,33 +1,33 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
 unix?: false
 win?: true
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: unix? "are equal" [
+test.skip: unix? "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: win? "are equal" [
+test.skip: win? "are equal" [
     assert -> 1 = code\fun
 ]
 
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-default/test/a/test2.art
+++ b/tests/test-default/test/a/test2.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 unix?: false
 win?: true

--- a/tests/test-default/test/other.art
+++ b/tests/test-default/test/other.art
@@ -1,33 +1,33 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
 unix?: false
 win?: true
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: unix? "are equal" [
+test.skip: unix? "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: win? "are equal" [
+test.skip: win? "are equal" [
     assert -> 1 = code\fun
 ]
 
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-default/test/other.art
+++ b/tests/test-default/test/other.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 unix?: false
 win?: true

--- a/tests/test-default/test/test1.art
+++ b/tests/test-default/test/test1.art
@@ -1,32 +1,30 @@
-code:  import.lean {src/code}
-unitt: import.lean {unitt}
-
-do ::
+code:  import.lean {src/code}!
+import {unitt}!
 
 unix?: false
 win?: true
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: unix? "are equal" [
+test.skip: unix? "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: win? "are equal" [
+test.skip: win? "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-default/test/test1.art
+++ b/tests/test-default/test/test1.art
@@ -1,5 +1,6 @@
-code:  import.lean {src/code}!
 import {unitt}!
+code:  import.lean {src/code}!
+
 
 unix?: false
 win?: true

--- a/tests/test-default/test/test2.art
+++ b/tests/test-default/test/test2.art
@@ -1,33 +1,33 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
 unix?: false
 win?: true
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: unix? "are equal" [
+test.skip: unix? "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test.skip: win? "are equal" [
+test.skip: win? "are equal" [
     assert -> 1 = code\fun
 ]
 
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-default/test/test2.art
+++ b/tests/test-default/test/test2.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 unix?: false
 win?: true

--- a/tests/test-default/tester.art
+++ b/tests/test-default/tester.art
@@ -1,6 +1,6 @@
 #! arturo
 
-import {unitt}
+import {unitt}!
 
-do ::
-    runTests "test"
+
+runTests "test"

--- a/tests/test-failfast/tester.art
+++ b/tests/test-failfast/tester.art
@@ -1,8 +1,7 @@
 #! arturo
 
-import {unitt}
+import {unitt}!
 
-do ::
 
-    runTests.failFast.suppress: "test*.runtime-error.art" "tests"
-    runTests.failFast.suppress: "test*.assertion-error.art" "tests"
+runTests.failFast.suppress: "test*.runtime-error.art" "tests"
+runTests.failFast.suppress: "test*.assertion-error.art" "tests"

--- a/tests/test-failfast/tests/test1.assertion-error.art
+++ b/tests/test-failfast/tests/test1.assertion-error.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "I must pass" [
     assert -> true

--- a/tests/test-failfast/tests/test1.assertion-error.art
+++ b/tests/test-failfast/tests/test1.assertion-error.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "I must pass" [
+test "I must pass" [
     assert -> true
 ]
 
-unitt\test "I must pass too" [
+test "I must pass too" [
     assert -> true
     assert -> true
 ]
 
-unitt\test "I must break the test" [
+test "I must break the test" [
     assert -> false
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> false
 ]

--- a/tests/test-failfast/tests/test1.runtime-error.art
+++ b/tests/test-failfast/tests/test1.runtime-error.art
@@ -1,21 +1,21 @@
 code:  import.lean {code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> true
 ]
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> true
     assert -> true
 ]
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> false
 ]
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> false
 ]

--- a/tests/test-failfast/tests/test1.runtime-error.art
+++ b/tests/test-failfast/tests/test1.runtime-error.art
@@ -1,7 +1,6 @@
+import {unitt}!
 code:  import.lean {code}
-import {unitt}
 
-do ::
 
 test "I must never run" [
     assert -> true

--- a/tests/test-failfast/tests/test2.assertion-error.art
+++ b/tests/test-failfast/tests/test2.assertion-error.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "I must pass" [
     assert -> true

--- a/tests/test-failfast/tests/test2.assertion-error.art
+++ b/tests/test-failfast/tests/test2.assertion-error.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "I must pass" [
+test "I must pass" [
     assert -> true
 ]
 
-unitt\test "I must pass too" [
+test "I must pass too" [
     assert -> true
     assert -> true
 ]
 
-unitt\test "I must break the test" [
+test "I must break the test" [
     assert -> false
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> false
 ]

--- a/tests/test-failfast/tests/test2.runtime-error.art
+++ b/tests/test-failfast/tests/test2.runtime-error.art
@@ -1,21 +1,21 @@
 code:  import.lean {code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> true
 ]
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> true
     assert -> true
 ]
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> false
 ]
 
-unitt\test "I must never run" [
+test "I must never run" [
     assert -> false
 ]

--- a/tests/test-failfast/tests/test2.runtime-error.art
+++ b/tests/test-failfast/tests/test2.runtime-error.art
@@ -1,7 +1,6 @@
+import {unitt}!
 code:  import.lean {code}
-import {unitt}
 
-do ::
 
 test "I must never run" [
     assert -> true

--- a/tests/test-finder/tests/append-test.art
+++ b/tests/test-finder/tests/append-test.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/append-test.art
+++ b/tests/test-finder/tests/append-test.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/append.art
+++ b/tests/test-finder/tests/append.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/append.art
+++ b/tests/test-finder/tests/append.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/append.test.art
+++ b/tests/test-finder/tests/append.test.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/append.test.art
+++ b/tests/test-finder/tests/append.test.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/drop-test.art
+++ b/tests/test-finder/tests/drop-test.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/drop-test.art
+++ b/tests/test-finder/tests/drop-test.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/drop.test.art
+++ b/tests/test-finder/tests/drop.test.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/drop.test.art
+++ b/tests/test-finder/tests/drop.test.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/dup.art
+++ b/tests/test-finder/tests/dup.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/dup.art
+++ b/tests/test-finder/tests/dup.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/test-append.art
+++ b/tests/test-finder/tests/test-append.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/test-append.art
+++ b/tests/test-finder/tests/test-append.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/tests/test-append.test.art
+++ b/tests/test-finder/tests/test-append.test.art
@@ -1,7 +1,6 @@
-code:  import.lean {src/code}
-import {unitt}
+import {unitt}!
+code:  import.lean {src/code}!
 
-do ::
 
 test "are equal" [
     assert -> 1 = code\fun

--- a/tests/test-finder/tests/test-append.test.art
+++ b/tests/test-finder/tests/test-append.test.art
@@ -1,21 +1,21 @@
 code:  import.lean {src/code}
-unitt: import.lean {unitt}
+import {unitt}
 
 do ::
 
-unitt\test "are equal" [
+test "are equal" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "are different" [
+test "are different" [
     assert -> 2 <> code\fun
     assert -> 3 <> code\fun
 ]
 
-unitt\test "will pass" [
+test "will pass" [
     assert -> 1 = code\fun
 ]
 
-unitt\test "will fail" [
+test "will fail" [
     assert -> 2 = code\fun
 ]

--- a/tests/test-finder/unitt-tester.art
+++ b/tests/test-finder/unitt-tester.art
@@ -1,14 +1,13 @@
 #! arturo
 
-import {unitt}
+import {unitt}!
 
-do ::
 
-    print "===> Finding *.art"
-    runTests.suppress.pattern: "*.art" "tests"
-    
-    print "===> Finding *.test.art"
-    runTests.suppress.pattern: "*.test.art" "tests"
-   
-    print "===> Finding test*.art"
-    runTests.suppress.pattern: "test*.art" "tests"
+print "===> Finding *.art"
+runTests.suppress.pattern: "*.art" "tests"
+
+print "===> Finding *.test.art"
+runTests.suppress.pattern: "*.test.art" "tests"
+
+print "===> Finding test*.art"
+runTests.suppress.pattern: "test*.art" "tests"

--- a/unitt.art
+++ b/unitt.art
@@ -20,10 +20,9 @@ runTests: $[testPath :string][
     ;;
     ;; example: {
     ;;      ; tester.art
-    ;;      import {unitt}
+    ;;      import {unitt}!
     ;;      
-    ;;      do ::
-    ;;          runTests {tests}   
+    ;;      runTests {tests}   
     ;; }
 
     ; Important to final statistics
@@ -114,9 +113,9 @@ test: $[description :string testCase :block][
     ;;
     ;; example: {
     ;;      ; testAppend.art
-    ;;      import {unitt}
+    ;;      import {unitt}!
     ;;      
-    ;;      do ::
+    ;;      
     ;;          test.prop "appending with keyword or operator has the same behavior" [
     ;;              a: [a b c d e f g]
     ;;              b: [h i j k l m n]


### PR DESCRIPTION
This PR goes totally the, now staged, issue #16. I'm not sure if drastically change the simplicity of this lib would be the best idea. I don't want to force users to use `unitt\<something>` or even need a runner to see the tests' output.

So, really, I opted out by deprecating the `.lean` importing. So, Always use `raw` importings.
The question was already discussed on PR #15.

---
References:
* #16
* #15