### PR TITLE
Feat evaluate runtime values

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,8 @@ so that is great if you're working with *Continuous Integration*.
     - `.skip :logical`:
         Skips tests for some condition. 
         If none condition is given, this will just skip the test.
+    - `.static: :block`:
+        Defines what will and what won't be evaluated.
 - `assert: $[condition :block]`:
     A function that is only available inside the `test` case,
     makes an assertion given the `condition`.

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,8 @@ so that is great if you're working with *Continuous Integration*.
         If none condition is given, this will just skip the test.
     - `.static: :block`:
         Defines what will and what won't be evaluated.
+    - `.static: :logical`:
+        Disable runtime evaluation, and forces static display.
 - `assert: $[condition :block]`:
     A function that is only available inside the `test` case,
     makes an assertion given the `condition`.

--- a/test.sh
+++ b/test.sh
@@ -88,3 +88,23 @@ diff --brief sample output ||           \
 rm unitt.art
 rm output
 cd ../..
+
+# ========== Running the test eval ========== #
+
+echo "Testing the test's values evaluation"
+
+# copying unitt to tests
+
+cp unitt.art tests/test-eval
+cd tests/test-eval
+
+# testing assertions
+./test.art > output 
+
+diff --brief sample output ||           \
+    diff --side-by-side sample output
+
+# cleaning test
+rm unitt.art
+rm output
+cd ../..

--- a/tests/test-default/sample
+++ b/tests/test-default/sample
@@ -2,101 +2,77 @@
 ===== test\test1.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : [2 <> code\fun]
-
+     assertion : 2 <> code\fun
 [0;33m✅ - assert that are different[0m 
-     assertion : [3 <> code\fun]
-
+     assertion : 3 <> code\fun
 [0;33m✅ - assert that will pass[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m❌ - assert that will fail[0m 
-     assertion : [2 = code\fun]
-
+     assertion : 2 = code\fun
 
 
 ===== test\test2.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : [2 <> code\fun]
-
+     assertion : 2 <> code\fun
 [0;33m✅ - assert that are different[0m 
-     assertion : [3 <> code\fun]
-
+     assertion : 3 <> code\fun
 [0;33m✅ - assert that will pass[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m❌ - assert that will fail[0m 
-     assertion : [2 = code\fun]
-
+     assertion : 2 = code\fun
 
 
 ===== test\a\test1.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : [2 <> code\fun]
-
+     assertion : 2 <> code\fun
 [0;33m✅ - assert that are different[0m 
-     assertion : [3 <> code\fun]
-
+     assertion : 3 <> code\fun
 [0;33m✅ - assert that will pass[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m❌ - assert that will fail[0m 
-     assertion : [2 = code\fun]
-
+     assertion : 2 = code\fun
 
 
 ===== test\a\test2.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m✅ - assert that are equal[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : [2 <> code\fun]
-
+     assertion : 2 <> code\fun
 [0;33m✅ - assert that are different[0m 
-     assertion : [3 <> code\fun]
-
+     assertion : 3 <> code\fun
 [0;33m✅ - assert that will pass[0m 
-     assertion : [1 = code\fun]
-
+     assertion : 1 = code\fun
 [0;33m❌ - assert that will fail[0m 
-     assertion : [2 = code\fun]
-
+     assertion : 2 = code\fun
 
 
 ===== Statistics =====
@@ -109,6 +85,6 @@
 ===== ========== =====
 
 [1;31m>> Program |[0m [1;90mFile: [0m[0;90mtester.art
-[1;31m     error |[0m [1;90mLine: [0m[0;90m91[0m
+[1;31m     error |[0m [1;90mLine: [0m[0;90m96[0m
            [1;31m|[0m 
            [1;31m|[0m Some tests failed!

--- a/tests/test-default/sample
+++ b/tests/test-default/sample
@@ -2,77 +2,101 @@
 ===== test\test1.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : 2 <> code\fun
+     assertion: 2 <> code\fun
+
 [0;33m✅ - assert that are different[0m 
-     assertion : 3 <> code\fun
+     assertion: 3 <> code\fun
+
 [0;33m✅ - assert that will pass[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m❌ - assert that will fail[0m 
-     assertion : 2 = code\fun
+     assertion: 2 = code\fun
+
 
 
 ===== test\test2.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : 2 <> code\fun
+     assertion: 2 <> code\fun
+
 [0;33m✅ - assert that are different[0m 
-     assertion : 3 <> code\fun
+     assertion: 3 <> code\fun
+
 [0;33m✅ - assert that will pass[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m❌ - assert that will fail[0m 
-     assertion : 2 = code\fun
+     assertion: 2 = code\fun
+
 
 
 ===== test\a\test1.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : 2 <> code\fun
+     assertion: 2 <> code\fun
+
 [0;33m✅ - assert that are different[0m 
-     assertion : 3 <> code\fun
+     assertion: 3 <> code\fun
+
 [0;33m✅ - assert that will pass[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m❌ - assert that will fail[0m 
-     assertion : 2 = code\fun
+     assertion: 2 = code\fun
+
 
 
 ===== test\a\test2.art =====
 
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m✅ - assert that are equal[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m⏩ - assert that are equal[0m 
      skipped! 
 
 [0;33m✅ - assert that are different[0m 
-     assertion : 2 <> code\fun
+     assertion: 2 <> code\fun
+
 [0;33m✅ - assert that are different[0m 
-     assertion : 3 <> code\fun
+     assertion: 3 <> code\fun
+
 [0;33m✅ - assert that will pass[0m 
-     assertion : 1 = code\fun
+     assertion: 1 = code\fun
+
 [0;33m❌ - assert that will fail[0m 
-     assertion : 2 = code\fun
+     assertion: 2 = code\fun
+
 
 
 ===== Statistics =====

--- a/tests/test-eval/sample
+++ b/tests/test-eval/sample
@@ -1,0 +1,57 @@
+Suite: Simple tests with :inline and :block 
+ 
+[0;33m    ✅ ~ assert that works recursively for :inline[0m 
+         assertion: append [a b c d e f g] [h i j k l m n] = [a b c d e f g] ++ [h i j k l m n]
+
+[0;33m    ✅ ~ assert that works recursively for :inline[0m 
+         assertion: append [h i j k l m n] [a b c d e f g] = [h i j k l m n] ++ [a b c d e f g]
+
+[0;33m    ✅ ~ assert that `append a b` is evaluated before-hand[0m 
+         assertion: [a b c d e f g h i j k l m n] = [a b c d e f g] ++ [h i j k l m n]
+
+[0;33m    ✅ ~ assert that considers `ab` as being static[0m 
+         assertion: ab = [a b c d e f g] ++ [h i j k l m n]
+
+[0;33m    ✅ ~ assert that considers everything as being static[0m 
+         assertion: ab = a ++ b
+
+
+Suite: Test pre-evaluation 
+ 
+[0;33m    ❌ ~ assert that is possible to evaluate before-hand with `@`[0m 
+         assertion: ((sum [2 3 4])) [1 2 3 4 5]
+
+[0;33m    ❌ ~ assert that is possible to evaluate before-hand with `@`[0m 
+         assertion: sum 2 3 4  1 2 3 4 5 
+
+[0;33m    ❌ ~ assert that is possible to evaluate before-hand with `@`[0m 
+         assertion: 9  1 2 3 4 5 
+
+[0;33m    ❌ ~ assert that `a` and `b` are considered static[0m 
+         assertion: a = b
+
+[0;33m    ❌ ~ assert that [] and -> are evaluated differently[0m 
+         assertion: a = b
+
+[0;33m    ❌ ~ assert that [] and -> are evaluated differently[0m 
+         assertion: ((sum [2 3 4])) = [1 2 3 4 5]
+
+[0;33m    ❌ ~ assert that `a` and `b` are evaluated before-hand[0m 
+         assertion: false
+
+
+Suite: Test completely static display 
+ 
+[0;33m    ❌ ~ assert that `a` and `b` are considered static[0m 
+         assertion: [a = b] 
+
+[0;33m    ❌ ~ assert that [] and -> are evaluated differently[0m 
+         assertion: [[a = b]] 
+
+[0;33m    ❌ ~ assert that [] and -> are evaluated differently[0m 
+         assertion: ((sum [2 3 4])) = [1 2 3 4 5]
+
+[0;33m    ❌ ~ assert that `a` and `b` is evaluated before-hand[0m 
+         assertion: [false] 
+
+

--- a/tests/test-eval/sample
+++ b/tests/test-eval/sample
@@ -22,10 +22,10 @@ Suite: Test pre-evaluation
          assertion: ((sum [2 3 4])) [1 2 3 4 5]
 
 [0;33m    ❌ ~ assert that is possible to evaluate before-hand with `@`[0m 
-         assertion: sum 2 3 4  1 2 3 4 5 
+         assertion: sum [2 3 4] [1 2 3 4 5]
 
 [0;33m    ❌ ~ assert that is possible to evaluate before-hand with `@`[0m 
-         assertion: 9  1 2 3 4 5 
+         assertion: [9] [1 2 3 4 5]
 
 [0;33m    ❌ ~ assert that `a` and `b` are considered static[0m 
          assertion: a = b

--- a/tests/test-eval/test.art
+++ b/tests/test-eval/test.art
@@ -1,0 +1,77 @@
+#! arturo
+
+import {unitt}!
+
+suite "Simple tests with :inline and :block" [
+
+    a: [a b c d e f g]
+    b: [h i j k l m n]
+
+    test.prop "works recursively for :inline" [
+        assert -> (append a b) = a ++ b
+        assert -> (append b a) = b ++ a
+    ]
+
+    test.prop "`append a b` is evaluated before-hand" [
+        ab: append a b
+        assert -> ab = a ++ b
+    ]
+
+    test.prop.static: [ab] "considers `ab` as being static" [
+        ab: append a b
+        assert -> ab = a ++ b
+    ]
+
+    test.prop.static: [a b ab] "considers everything as being static" [
+        ab: append a b
+        assert -> ab = a ++ b
+    ]
+
+]
+
+suite "Test pre-evaluation" [
+
+    a: to :inline -> (sum [2 3 4])
+    b: [1 2 3 4 5]
+
+    test.prop "is possible to evaluate before-hand with `@`" [
+        assert [a b]
+        assert @[a b]
+        assert @[@ to :block a b]
+    ]
+
+    test.prop.static: [a b] "`a` and `b` are considered static" [
+        assert [a = b]
+    ]
+
+    test.prop.static: [a b] "[] and -> are evaluated differently" [
+        assert [(a = b)]    ; static evaluated
+        assert -> (a = b)   ; evaluated before-hand
+    ]
+
+    test.prop.static: [a b] "`a` and `b` are evaluated before-hand" [
+        assert @[a = b]
+    ]
+
+]
+
+
+suite "Test completely static display" [
+
+    a: to :inline -> (sum [2 3 4])
+    b: [1 2 3 4 5]
+
+    test.prop.static "`a` and `b` are considered static" [
+        assert [a = b]
+    ]
+
+    test.prop.static "[] and -> are evaluated differently" [
+        assert [(a = b)]    ; static evaluated
+        assert -> (a = b)   ; evaluated before-hand
+    ]
+
+    test.prop.static "`a` and `b` is evaluated before-hand" [
+        assert @[a = b]
+    ]
+
+]

--- a/tests/test-failfast/sample
+++ b/tests/test-failfast/sample
@@ -2,15 +2,20 @@
 ===== tests\test1.assertion-error.art =====
 
 [0;33m✅ - assert that I must pass[0m 
-     assertion : true
+     assertion: true
+
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : true
+     assertion: true
+
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : true
+     assertion: true
+
 [0;33m❌ - assert that I must break the test[0m 
-     assertion : false
+     assertion: false
+
 [0;33m❌ - assert that will fail[0m 
-     assertion : false
+     assertion: false
+
 
 
 ===== Statistics =====
@@ -26,15 +31,20 @@
 ===== tests\test1.assertion-error.art =====
 
 [0;33m✅ - assert that I must pass[0m 
-     assertion : true
+     assertion: true
+
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : true
+     assertion: true
+
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : true
+     assertion: true
+
 [0;33m❌ - assert that I must break the test[0m 
-     assertion : false
+     assertion: false
+
 [0;33m❌ - assert that will fail[0m 
-     assertion : false
+     assertion: false
+
 
 
 ===== Statistics =====

--- a/tests/test-failfast/sample
+++ b/tests/test-failfast/sample
@@ -2,20 +2,15 @@
 ===== tests\test1.assertion-error.art =====
 
 [0;33m✅ - assert that I must pass[0m 
-     assertion : [true]
-
+     assertion : true
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : [true]
-
+     assertion : true
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : [true]
-
+     assertion : true
 [0;33m❌ - assert that I must break the test[0m 
-     assertion : [false]
-
+     assertion : false
 [0;33m❌ - assert that will fail[0m 
-     assertion : [false]
-
+     assertion : false
 
 
 ===== Statistics =====
@@ -31,20 +26,15 @@
 ===== tests\test1.assertion-error.art =====
 
 [0;33m✅ - assert that I must pass[0m 
-     assertion : [true]
-
+     assertion : true
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : [true]
-
+     assertion : true
 [0;33m✅ - assert that I must pass too[0m 
-     assertion : [true]
-
+     assertion : true
 [0;33m❌ - assert that I must break the test[0m 
-     assertion : [false]
-
+     assertion : false
 [0;33m❌ - assert that will fail[0m 
-     assertion : [false]
-
+     assertion : false
 
 
 ===== Statistics =====

--- a/tests/test-suite/sample
+++ b/tests/test-suite/sample
@@ -1,20 +1,16 @@
 [0;33m✅ - assert that I'm not indented[0m 
-     assertion : [true]
-
+     assertion : true
 Suite: Indenting tests 
  
 [0;33m    ✅ - assert that I'm indented[0m 
-         assertion : [true]
-
+         assertion : true
 [0;33m    ⏩ - assert that I'm indented[0m 
          skipped! 
 
 [0;33m    ❌ - assert that I'm indented[0m 
-         assertion : [false]
-
+         assertion : false
 [0;33m⏩ - assert that I'm not indented[0m 
      skipped! 
 
 [0;33m❌ - assert that I'm not indented[0m 
-     assertion : [false]
-
+     assertion : false

--- a/tests/test-suite/sample
+++ b/tests/test-suite/sample
@@ -1,16 +1,21 @@
 [0;33m✅ - assert that I'm not indented[0m 
-     assertion : true
+     assertion: true
+
 Suite: Indenting tests 
  
 [0;33m    ✅ - assert that I'm indented[0m 
-         assertion : true
+         assertion: true
+
 [0;33m    ⏩ - assert that I'm indented[0m 
          skipped! 
 
 [0;33m    ❌ - assert that I'm indented[0m 
-         assertion : false
+         assertion: false
+
+
 [0;33m⏩ - assert that I'm not indented[0m 
      skipped! 
 
 [0;33m❌ - assert that I'm not indented[0m 
-     assertion : false
+     assertion: false
+

--- a/unitt.art
+++ b/unitt.art
@@ -176,6 +176,7 @@ test: $[description :string testCase :block][
     ;;      ]
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
     ;;      ;      assertion : ( append [a b c d e f g] [h i j k l m n] ) = [a b c d e f g] ++ [h i j k l m n]
+    ;;      ;
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior
     ;;      ;      assertion : ( append [h i j k l m n] [a b c d e f g] ) = [h i j k l m n] ++ [a b c d e f g]
     ;;          
@@ -253,7 +254,7 @@ test: $[description :string testCase :block][
 
         prints ~"|_unittTestsIndentation|     assertion :"
         evaluateExpression condition
-        prints "\n"
+        print "\n"
 
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -177,17 +177,17 @@ test: $[description :string testCase :block][
     ;;          assert -> (append b a) = b ++ a
     ;;      ]
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
-    ;;      ;      assertion : ( append [a b c d e f g] [h i j k l m n] ) = [a b c d e f g] ++ [h i j k l m n]
+    ;;      ;      assertion: append [a b c d e f g] [h i j k l m n] = [a b c d e f g] ++ [h i j k l m n]
     ;;      ;
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior
-    ;;      ;      assertion : ( append [h i j k l m n] [a b c d e f g] ) = [h i j k l m n] ++ [a b c d e f g]
+    ;;      ;      assertion: append [h i j k l m n] [a b c d e f g] = [h i j k l m n] ++ [a b c d e f g]
     ;;          
     ;;      test.skip: unix? "split is working for windows's paths" [
     ;;          assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
     ;;      ]
     ;;      ; # running on Windows:
     ;;      ; ✅ - assert that split is working for windows's paths
-    ;;      ;      assertion : ["." "splited" "path"] = split .path ".\\splited\\path"
+    ;;      ;      assertion: . splited path  = split path .\splited\path
     ;;      ; 
     ;;      ; # running on Unix:
     ;;      ; ⏩ - assert that split is working for windows's paths 

--- a/unitt.art
+++ b/unitt.art
@@ -204,7 +204,7 @@ test: $[description :string testCase :block][
         ]
 
         (skip?)? -> do skipBlock [
-            (do condition)? 
+            (equal? @condition @[true])? 
                 passBlock
                 failBlock
 

--- a/unitt.art
+++ b/unitt.art
@@ -208,7 +208,16 @@ test: $[description :string testCase :block][
                 passBlock
                 failBlock
 
-            print ~"|_unittTestsIndentation|     assertion : |condition|\n"
+            prints ~"|_unittTestsIndentation|     assertion :"
+
+            loop.with: 'i condition 'cond [
+                prints " "
+                (throws? [el: var cond])?
+                    -> prints cond
+                    -> prints el
+            ]
+
+            prints "\n"
         ]
     ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -203,18 +203,23 @@ test: $[description :string testCase :block][
             print ~"|_unittTestsIndentation|     skipped! \n"
         ]
 
+        statics: (attr 'static) ?? []
+
         (skip?)? -> do skipBlock [
             (equal? @condition @[true])? 
                 passBlock
                 failBlock
 
             prints ~"|_unittTestsIndentation|     assertion :"
-
+            staticTypes: [:function :literal :pathLiteral]
             loop.with: 'i condition 'cond [
                 prints " "
-                (throws? [el: var cond])?
-                    -> prints cond
-                    -> prints el
+                
+                (or? throws? [el: var cond] in? cond statics)? 
+                    -> prints as.code cond
+                    -> (in? type el staticTypes)? 
+                        -> prints as.code cond
+                        -> prints as.code el
             ]
 
             prints "\n"

--- a/unitt.art
+++ b/unitt.art
@@ -158,6 +158,7 @@ test: $[description :string testCase :block][
     ;;      prop: :logical « defines if a test is property-based
     ;;      skip: :logical « skip test if true
     ;;      static: :block « defines what should not be evaluated when showing
+    ;;      static: :logical « disables runtime eval, forces static display
     ;; ]
     ;;
     ;; note: {

--- a/unitt.art
+++ b/unitt.art
@@ -215,27 +215,27 @@ test: $[description :string testCase :block][
         ]
 
         evaluateExpression: $[expr][
+            statics: statics
             staticTypes: [:function :literal :pathLiteral]
-            loop expr 'value [
-                prints " "
-
-                if inline? value [
-                    prints "("
-                    _: evaluateExpression to :block value
-                    prints " )"
+            staticPrinting: [
+                    prints " "
+                    prints value
+                    continue
+                ]
+            
+            loop expr 'value [                
+                if inline? value  [
+                    _: evaluateExpression to :inline value
                     continue
                 ]
 
-                if or? throws? [val: var value] in? value statics [
-                    prints as.code value
-                    continue
-                ]
+                if or? throws? [val: var value] in? value statics
+                    staticPrinting
 
-                if in? type val staticTypes [
-                    prints as.code value
-                    continue
-                ]
+                if in? type val staticTypes 
+                    staticPrinting
                 
+                prints " "
                 prints as.code val
             ]
 

--- a/unitt.art
+++ b/unitt.art
@@ -222,7 +222,7 @@ test: $[description :string testCase :block][
             staticTypes: [:function :literal :pathLiteral]
             staticPrinting: [
                     prints " "
-                    prints value
+                    prints as.code value
                     continue
                 ]
             

--- a/unitt.art
+++ b/unitt.art
@@ -207,6 +207,8 @@ test: $[description :string testCase :block][
     assert: $[condition :block][
 
         statics: (attr 'static) ?? []
+        forceStatic?: statics = true
+
         passBlock: -> print [color #yellow ~"|_unittTestsIndentation|✅ |template|"]
         failBlock: -> print [color #yellow ~"|_unittTestsIndentation|❌ |template|"]
         skipBlock: [ 
@@ -252,8 +254,14 @@ test: $[description :string testCase :block][
             passBlock
             failBlock
 
-        prints ~"|_unittTestsIndentation|     assertion :"
-        evaluateExpression condition
+        prints ~"|_unittTestsIndentation|     assertion:"
+        
+        (forceStatic?)? [
+            prints " "
+            prints -> condition
+        ][
+            evaluateExpression condition
+        ]
         print "\n"
 
     ]

--- a/unitt.art
+++ b/unitt.art
@@ -161,7 +161,6 @@ test: $[description :string testCase :block][
     ;;
     ;; note: {
     ;;    * `assert` is injected, and only available inside the `test`'s block.
-    ;;    * :inline values are considered as static.
     ;; }
     ;; 
     ;; example: {
@@ -172,16 +171,13 @@ test: $[description :string testCase :block][
     ;;          a: [a b c d e f g]
     ;;          b: [h i j k l m n]
     ;;
-    ;;          abBlk: append a b
-    ;;          baBlk: append b a
-    ;;
-    ;;          assert -> abBlk = a ++ b
-    ;;          assert -> baBlk = b ++ a
+    ;;          assert -> (append a b) = a ++ b
+    ;;          assert -> (append b a) = b ++ a
     ;;      ]
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
-    ;;      ;      assertion : [a b c d e f g h i j k l m n] = [a b c d e f g] ++ [h i j k l m n]
+    ;;      ;      assertion : ( append [a b c d e f g] [h i j k l m n] ) = [a b c d e f g] ++ [h i j k l m n]
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior
-    ;;      ;      assertion : [h i j k l m n a b c d e f g] = [h i j k l m n] ++ [a b c d e f g]
+    ;;      ;      assertion : ( append [h i j k l m n] [a b c d e f g] ) = [h i j k l m n] ++ [a b c d e f g]
     ;;          
     ;;      test.skip: unix? "split is working for windows's paths" [
     ;;          assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
@@ -208,6 +204,7 @@ test: $[description :string testCase :block][
 
     assert: $[condition :block][
 
+        statics: (attr 'static) ?? []
         passBlock: -> print [color #yellow ~"|_unittTestsIndentation|✅ |template|"]
         failBlock: -> print [color #yellow ~"|_unittTestsIndentation|❌ |template|"]
         skipBlock: [ 
@@ -215,7 +212,35 @@ test: $[description :string testCase :block][
             print ~"|_unittTestsIndentation|     skipped! \n"
         ]
 
-        statics: (attr 'static) ?? []
+        evaluateExpression: $[expr][
+            staticTypes: [:function :literal :pathLiteral]
+            loop expr 'value [
+                prints " "
+
+                if inline? value [
+                    prints "("
+                    _: evaluateExpression to :block value
+                    prints " )"
+                    continue
+                ]
+
+                if or? throws? [val: var value] in? value statics [
+                    prints as.code value
+                    continue
+                ]
+
+                if in? type val staticTypes [
+                    prints as.code value
+                    continue
+                ]
+                
+                prints as.code val
+            ]
+
+            return null
+
+        ]
+
 
         (skip?)? -> do skipBlock [
             (equal? @condition @[true])? 
@@ -223,17 +248,7 @@ test: $[description :string testCase :block][
                 failBlock
 
             prints ~"|_unittTestsIndentation|     assertion :"
-            staticTypes: [:function :literal :pathLiteral]
-            loop.with: 'i condition 'cond [
-                prints " "
-                
-                (or? throws? [el: var cond] in? cond statics)? 
-                    -> prints as.code cond
-                    -> (in? type el staticTypes)? 
-                        -> prints as.code cond
-                        -> prints as.code el
-            ]
-
+            evaluateExpression condition
             prints "\n"
         ]
     ]

--- a/unitt.art
+++ b/unitt.art
@@ -156,37 +156,49 @@ test: $[description :string testCase :block][
     ;; options: [
     ;;      prop: :logical « defines if a test is property-based
     ;;      skip: :logical « skip test if true
+    ;;      static: :block « defines what should not be evaluated when showing
     ;; ]
     ;;
-    ;; note: « `assert` is injected, and only available inside the `test`'s block.
-    ;;
+    ;; note: {
+    ;;    * `assert` is injected, and only available inside the `test`'s block.
+    ;;    * :inline values are considered as static.
+    ;; }
+    ;; 
     ;; example: {
     ;;      ; testAppend.art
     ;;      import {unitt}!
     ;;      
-    ;;      
     ;;      test.prop "appending with keyword or operator has the same behavior" [
     ;;          a: [a b c d e f g]
     ;;          b: [h i j k l m n]
-    ;;          assert -> (append a b) = (a ++ b)
-    ;;          assert -> (append b a) = (b ++ a)
+    ;;
+    ;;          abBlk: append a b
+    ;;          baBlk: append b a
+    ;;
+    ;;          assert -> abBlk = a ++ b
+    ;;          assert -> baBlk = b ++ a
     ;;      ]
     ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
-    ;;      ; assertion : [[append a b] = [a ++ b]]
-    ;;      ;
-    ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior 
-    ;;      ; assertion : [[append b a] = [b ++ a]]
+    ;;      ;      assertion : [a b c d e f g h i j k l m n] = [a b c d e f g] ++ [h i j k l m n]
+    ;;      ; ✅ ~ assert that appending with keyword or operator has the same behavior
+    ;;      ;      assertion : [h i j k l m n a b c d e f g] = [h i j k l m n] ++ [a b c d e f g]
     ;;          
     ;;      test.skip: unix? "split is working for windows's paths" [
     ;;          assert -> ["." "splited" "path"] = split.path ".\\splited\\path"
     ;;      ]
     ;;      ; # running on Windows:
-    ;;      ; ✅ - assert that split is working for windows's paths 
-    ;;      ; assertion : [[. splited path] = split path .\splited\path]
+    ;;      ; ✅ - assert that split is working for windows's paths
+    ;;      ;      assertion : ["." "splited" "path"] = split .path ".\\splited\\path"
     ;;      ; 
     ;;      ; # running on Unix:
     ;;      ; ⏩ - assert that split is working for windows's paths 
-    ;;      ; 
+    ;;      
+    ;;      test.static: [a] "`a` won't be evaluated" [
+    ;;          assert -> a = 5 
+    ;;      ]
+    ;;      ; ✅ - assert that `a` won't be evaluated 
+    ;;      ;      assertion : a = 5
+    ;;
     ;; }
 
     sep: (attr 'prop)? -> "~" -> "-"

--- a/unitt.art
+++ b/unitt.art
@@ -242,15 +242,19 @@ test: $[description :string testCase :block][
         ]
 
 
-        (skip?)? -> do skipBlock [
-            (equal? @condition @[true])? 
-                passBlock
-                failBlock
-
-            prints ~"|_unittTestsIndentation|     assertion :"
-            evaluateExpression condition
-            prints "\n"
+        if skip? [
+            do skipBlock
+            return null
         ]
+
+        (equal? @condition @[true])? 
+            passBlock
+            failBlock
+
+        prints ~"|_unittTestsIndentation|     assertion :"
+        evaluateExpression condition
+        prints "\n"
+
     ]
 
     do testCase

--- a/unitt.art
+++ b/unitt.art
@@ -243,7 +243,6 @@ test: $[description :string testCase :block][
 
         ]
 
-
         if skip? [
             do skipBlock
             return null

--- a/unitt.art
+++ b/unitt.art
@@ -139,6 +139,7 @@ suite: $[description :string tests :block][
     print ["Suite:" description "\n"]
     _unittTestsIndentation: "    "
     do tests
+    print ""
 ]
 
 

--- a/update-tests.sh
+++ b/update-tests.sh
@@ -31,10 +31,21 @@ rm unitt.art
 cd ../..
 
 # ========== Running the test suite ========== #
+
 cp unitt.art tests/test-suite
 cd tests/test-suite
 
 ./suite.test.art > sample
+
+rm unitt.art
+cd ../..
+
+# ========== Running the test eval ========== #
+
+cp unitt.art tests/test-eval
+cd tests/test-eval
+
+./test.art > sample
 
 rm unitt.art
 cd ../..

--- a/update-tests.sh
+++ b/update-tests.sh
@@ -1,0 +1,40 @@
+#! bash
+
+# ========== Running the default test ========== #
+
+cp unitt.art tests/test-default
+cd tests/test-default
+
+./tester.art > sample
+
+rm unitt.art
+cd ../..
+
+# ========== Running the finder test ========== #
+
+cp unitt.art tests/test-finder
+cd tests/test-finder
+
+./tester.art > sample
+
+rm unitt.art
+cd ../..
+
+# ========== Running the failfast ========== #
+
+cp unitt.art tests/test-failfast
+cd tests/test-failfast
+
+./tester.art > sample
+
+rm unitt.art
+cd ../..
+
+# ========== Running the test suite ========== #
+cp unitt.art tests/test-suite
+cd tests/test-suite
+
+./suite.test.art > sample
+
+rm unitt.art
+cd ../..


### PR DESCRIPTION
Evaluate runtime values
---

### At a Glance

```art
a: 5
test "a is 5" [
  assert -> 5 = a
]
; ✅ - assert that a is 5 
;     assertion: 5 = 5
```

To disable runtime evaluation, you can just pass `.static: [a]` to just for `a` or even just `.static` for all variables.

Here is how a real test looks-like:

![image](https://github.com/RickBarretto/unitt/assets/78623871/0e8031c7-db7a-464c-994f-6644ba18b264)

### Drawbacks

* Probably some issues may appear when dealing with `:inline` values. Please, report a bug or help doing a PR. 🙂 
* Depending the way you write, the display may be different, so test and take care before putting anything anywhere.
* Be aware about the concatenative nature of Arturo. This may imply some limitations and also some super-powers! 🦸

**Example:**

```art
suite "Test completely static display" [
    a: to :inline -> (sum [2 3 4])
    b: [1 2 3 4 5]

    test.prop.static "[] and -> are evaluated differently" [
        assert [(a = b)]    ; static evaluated
        assert -> (a = b)   ; evaluated before-hand
    ]
]
```

### Original Propose
* #6, thanks to @BNAndras

---

* Closes #6 