### PR TITLE
Changes: decouple runner and finder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,22 +147,25 @@ so that is great if you're working with *Continuous Integration*.
 ## Documentation
 
 ### *Runner*
-- `runTests: $[folder :string]`:
-    The *runner function*, this function will look for *tests* inside the relative `folder`.
-    Remember that all *tests* must begin with the `test` prefix, and be an `.art` extension.
+- `runTests: $[tests [:string]]`:
+    The *runner function*, this executes all `tests`,
+    show statistics and return a value. 
     - `.failFast`:
         Fails on the first error found. 
         This works at file scope due to our current way of running tests.
-    - `.pattern :string`:
-        Defines what is a test-file via a kind-of *glob* pattern.
-        Use a `*` as spliter. 
-        - Obs.: That is a kind-of *glob* pattern, not a real one. 
-          So just use one and only one `*` to split the pre and suffix.
     - `.suppress`: 
         Suppress `panic`, this means: 
         this won't terminate your tests, 
         won't return an error code
         and won't print a `panic` message. 
+- `findTests: $[folder :string]`:
+    The *finder function*, this function will look for *tests* inside the relative `folder`.
+    The default *test* pattern is "test*.art".
+    - `.thatMatches :string`:
+        Defines what is a test-file via a kind-of *glob* pattern.
+        Use a `*` as spliter. 
+        - Obs.: That is a kind-of *glob* pattern, not a real one. 
+          So just use one and only one `*` to split the pre and suffix.
 
 ### *Tests*
 - `test: $[description :string, testCase :block]`:

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Into your `tester.art`, you must:
 ```art
 import {unitt}!
 
-runTests "tests"
+runTests findTests "tests"
 ```
 
 To run it, call:

--- a/tests/test-default/sample
+++ b/tests/test-default/sample
@@ -109,6 +109,6 @@
 ===== ========== =====
 
 [1;31m>> Program |[0m [1;90mFile: [0m[0;90mtester.art
-[1;31m     error |[0m [1;90mLine: [0m[0;90m96[0m
+[1;31m     error |[0m [1;90mLine: [0m[0;90m123[0m
            [1;31m|[0m 
            [1;31m|[0m Some tests failed!

--- a/tests/test-default/tester.art
+++ b/tests/test-default/tester.art
@@ -3,4 +3,4 @@
 import {unitt}!
 
 
-runTests "test"
+runTests findTests "test"

--- a/tests/test-failfast/sample
+++ b/tests/test-failfast/sample
@@ -1,29 +1,19 @@
 
-===== tests\test1.assertion-error.art =====
+===== tests\test1.runtime-error.art =====
 
-[0;33m✅ - assert that I must pass[0m 
-     assertion: true
-
-[0;33m✅ - assert that I must pass too[0m 
-     assertion: true
-
-[0;33m✅ - assert that I must pass too[0m 
-     assertion: true
-
-[0;33m❌ - assert that I must break the test[0m 
-     assertion: false
-
-[0;33m❌ - assert that will fail[0m 
-     assertion: false
-
+[1;31m>> Runtime |[0m [1;90mFile: [0m[0;90mtest1.runtime-error.art
+[1;31m     error |[0m [1;90mLine: [0m[0;90m299[0m
+           [1;31m|[0m 
+           [1;31m|[0m package not found:
+           [1;31m|[0m [1mcode[0m
 
 
 ===== Statistics =====
 
-⏏️    TOTAL: 5 assertions
-✅  PASSED: 3 assertions
+⏏️    TOTAL: 0 assertions
+✅  PASSED: 0 assertions
 ⏩ SKIPPED: 0 assertions
-❌  FAILED: 2 assertions
+❌  FAILED: 0 assertions
 
 ===== ========== =====
 

--- a/tests/test-failfast/tester.art
+++ b/tests/test-failfast/tester.art
@@ -2,6 +2,9 @@
 
 import {unitt}!
 
+patterns: map ["runtime" "assertion"] 'kind
+    -> ~"test*.|kind|-error.art"
 
-runTests.failFast.suppress: "test*.runtime-error.art" "tests"
-runTests.failFast.suppress: "test*.assertion-error.art" "tests"
+loop patterns 'pattern
+    -> runTests.failFast.suppress 
+        findTests.thatMatches: pattern "tests"

--- a/tests/test-finder/unitt-tester.art
+++ b/tests/test-finder/unitt-tester.art
@@ -4,10 +4,10 @@ import {unitt}!
 
 
 print "===> Finding *.art"
-runTests.suppress.pattern: "*.art" "tests"
+runTests.suppress findTests.thatMatches: "*.art" "tests"
 
 print "===> Finding *.test.art"
-runTests.suppress.pattern: "*.test.art" "tests"
+runTests.suppress findTests.thatMatches: "*.test.art" "tests"
 
 print "===> Finding test*.art"
-runTests.suppress.pattern: "test*.art" "tests"
+runTests.suppress findTests.thatMatches: "test*.art" "tests"

--- a/unitt.art
+++ b/unitt.art
@@ -9,25 +9,72 @@
 ;;    At least, for now. This may change in future updates.
 ;; }
 ;;
-;; export: ['runTests 'test]
+;; export: ['runTests 'findTests 'test 'suite]
 
-runTests: $[testPath :string][
-    ;; description: « executes test-files inside the `testPath`
+
+findTests: $[testPath :string][
+    ;; description: « finds test files into `testPath`
     ;;
     ;; arguments: [
     ;;      testPath: « the relative folder that contains the tests
     ;; ]
     ;; options: [
-    ;;      failFast: :logical « fails on the first error found. (at file scope)
-    ;;      pattern:  :string  « a simple glob-like pattern to select files.
-    ;;      suppress: :logical « suppress exit codes.
+    ;;      thatMatches: :string {
+    ;;          a simple glob-like pattern to select files.
+    ;;          the default value is "test*.art".
+    ;;      }
     ;; ]
     ;;
     ;; example: {
     ;;      ; tester.art
     ;;      import {unitt}!
     ;;      
-    ;;      runTests {tests}   
+    ;;      runTests findTests.thatMatches: "*.test.art" "tests"   
+    ;; }
+
+    pattern: (attr 'thatMatches)?? "test*.art"
+
+    ensure.that: ~".pattern: '|pattern|' must have only one wildcard '*'."
+        -> one? enumerate pattern 'ch -> ch = '*'
+
+
+    testPrefix: first split.by: "*" pattern
+    testSuffix: last  split.by: "*" pattern
+
+    testFile?: $[file :string][
+        filename: last split.path file
+        and? 
+            prefix? filename testPrefix
+            suffix? filename testSuffix
+    ]
+
+    list.recursive testPath | select => testFile?
+
+]
+
+runTests: $[files :block][
+    ;; description: « executes test-files
+    ;;
+    ;; arguments: [
+    ;;      files: « a block containing the path to the files.
+    ;; ]
+    ;; options: [
+    ;;      failFast: :logical « fails on the first error found. (at file scope)
+    ;;      suppress: :logical « suppress exit codes.
+    ;; ]
+    ;;
+    ;; deprecated: [
+    ;;      option 'pattern :string: since 0.2.1
+    ;;          "See `findTests`."
+    ;; ]
+    ;;
+    ;; seeAlso: [findTests]
+    ;;
+    ;; examples: {
+    ;;      ; tester.art
+    ;;      import {unitt}!
+    ;;      
+    ;;      runTests ["tests/test01.art"]
     ;; }
 
     ; Important to final statistics
@@ -41,28 +88,8 @@ runTests: $[testPath :string][
     fatalError: false
     failFast: logical? attr 'failFast
 
-    pattern: (attr 'pattern)?? "test*.art"
-
-    ensure.that: ~".pattern: '|pattern|' must have only one wildcard '*'."
-        -> one? enumerate pattern 'ch -> ch = '*'
-
-    testPrefix: first split.by: "*" pattern
-    testSuffix: last  split.by: "*" pattern
-
-    testFile?: $[file :string][
-        ;; description: « Checks if `file` starts with 'test' and is an .art file
-
-        filename: last split.path file
-
-        and? 
-            prefix? filename testPrefix
-            suffix? filename testSuffix
-    ]
-
-    testfiles: list.recursive testPath | select => testFile?
-
     ; The tests execution
-    loop testfiles 'file [ 
+    loop files 'file [ 
         print ~"\n===== |file| =====\n"
 
         result: execute.code ~"|sys\binary| |file|"


### PR DESCRIPTION
## Decouple test runner and test finder

### At a Glance

```art
import {unitt}!

runTests findTests.thatMatches: "*.test.art" "tests"
```

### Deprecation

This way `runTests.patttern` was deprecated, and should not be used anymore. Also, runTests now gets `[:string]` instead of `:string`.

### Original Propose
* #20 

---
* Closes #20


