### PR TITLE
Implement: `assert.with` feature

### DIFF
--- a/src/internal/test.art
+++ b/src/internal/test.art
@@ -112,6 +112,8 @@ test: $[description :string testCase :block][
 
     __assertions: @[]
     assert: $[condition :block][
+        if (fn: <= (attr 'with)?? null)
+            -> condition: flatten @[to :word fn] ++ @[condition]
         '__assertions ++ to :assertion @[condition]
     ]
 

--- a/test.art
+++ b/test.art
@@ -6,6 +6,8 @@ if standalone?
 test "this passes" [
     a: 1
     assert -> true
+    assert.with: 'equal? @[3 add a 2]
+    assert.with: 'equal? [3 add a 2]
     assert -> equal? 3 (add a 2)
     assert.static -> equal? 3 (add a 2)
 ]


### PR DESCRIPTION
## At A Glance

**Test**

```art
test "this passes" [
    a: 1
    assert.with: 'equal? @[3 add a 2]
    assert.with: 'equal? [3 add a 2]
]
```

**Result**

```
✅ - assert that this passes
     assertion: equal? 3 3
     assertion: equal? 3 add 1 2
```

## Reference
- Closes #30
