### PR TITLE
Implementing RSpec-ish API

### DIFF
--- a/src/internal/suite.art
+++ b/src/internal/suite.art
@@ -40,3 +40,6 @@ suite: $[description :string tests :block][
     do tests
     print ""
 ]
+
+spec: var 'suite
+describe: var 'suite

--- a/src/internal/test.art
+++ b/src/internal/test.art
@@ -117,6 +117,8 @@ test: $[description :string testCase :block][
         '__assertions ++ to :assertion @[condition]
     ]
 
+    expects: var 'assert
+
     do testCase
     _self: to :test @[description __assertions]
     print to :string _self

--- a/src/internal/test.art
+++ b/src/internal/test.art
@@ -112,8 +112,9 @@ test: $[description :string testCase :block][
 
     __assertions: @[]
     assert: $[condition :block][
-        if (fn: <= (attr 'with)?? null)
-            -> condition: flatten @[to :word fn] ++ @[condition]
+        __fn: @[attr 'with attr 'to attr 'be ] | filter => null?
+        if not? empty? __fn
+            -> condition: flatten @[to :word last __fn] ++ @[condition]
         '__assertions ++ to :assertion @[condition]
     ]
 

--- a/src/internal/test.art
+++ b/src/internal/test.art
@@ -122,3 +122,6 @@ test: $[description :string testCase :block][
     print to :string _self
     'unitt ++ _self
 ]
+
+it: var 'test
+should: var 'test

--- a/test.art
+++ b/test.art
@@ -9,7 +9,7 @@ test "this passes" [
     assert.with: 'equal? @[3 add a 2]
     assert.with: 'equal? [3 add a 2]
     assert -> equal? 3 (add a 2)
-    assert.static -> equal? 3 (add a 2)
+    expects.static -> equal? 3 (add a 2)
 ]
 
 test.skip "this skips" [
@@ -29,12 +29,14 @@ test "this fails" [
 
 suite "group 1" [
     test "..." []
-    test "..." []
+]
+
+describe "group 2" [
+    it "..." []
+    should "..." []
     test "..." []
 ]
 
-suite "group 2" [
-    test "..." []
-    test "..." []
+spec "group 3" [
     test "..." []
 ]

--- a/test.art
+++ b/test.art
@@ -6,7 +6,8 @@ if standalone?
 test "this passes" [
     a: 1
     assert -> true
-    assert.with: 'equal? @[3 add a 2]
+    expects.to.be: 'equal? @[3 add a 2]
+    expects.be: 'equal? [3 add a 2]
     assert.with: 'equal? [3 add a 2]
     assert -> equal? 3 (add a 2)
     expects.static -> equal? 3 (add a 2)


### PR DESCRIPTION
## At A Glance

They are all the same:

```
suite "name" [ ... ]
describe "name" [ ... ]
spec "name" [ ... ]
```

```
assert [ ... ]
expects [ ... ]
```

```
assert.with: 'equal? @[3 add 1 2]
expects.be: 'equal? @[3 add 1 2]
expects.to.be: 'equal? @[3 add 1 2]
expects.to: 'contains? @[container value]
```

## Real example

```
spec "`append`ing `[:binary]`s" [

  should "return [:binary]" [
    loop permutate.repeated new binaries 'entries [
      a: first entries
      b: last entries
      expects.to.be: 'binary @[append a b]
    ]
  ]

  it "inplaced should have the same behavior" [
    [a]: first new binaries
    b: 1

    [reference inplaced pathInplaced]: fullInplaceEquivalence (a) 'append @[b]

    expects.be: 'equal? @[reference inplaced]
    expects.be: 'equal? @[inplaced pathInplaced]
  ]
]
```

## Reference
- #28 