### PR TITLE
Add more commands

### DIFF
--- a/unitt.toml
+++ b/unitt.toml
@@ -10,3 +10,6 @@ tests = "specs"
 # File pattern for test files
 # (default: "**.spec.art")
 target = "**/*.spec.art"
+
+# Arturo binary path
+arturo = "./bin/arturo.exe"

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -11,7 +11,7 @@ use crate::models::config::Config;
 pub struct Arguments {
     #[arg(long, default_value="specs", help="Path to test files directory.")]
     pub tests: String,
-    #[arg(long, default_value="unitt", help="Path to cache directory.")]
+    #[arg(long, default_value=".unitt", help="Path to cache directory.")]
     pub cache: String,
     #[arg(long, default_value="**/*.spec.art", help="Glob pattern to match test files.")]
     pub target: String,

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -9,32 +9,32 @@ use crate::models::config::Config;
 #[command(version, author="RickBarretto")]
 #[command(about = "Lean unit testing tool for Arturo")]
 pub struct Arguments {
-    #[arg(long, default_value="specs", help="Path to test files directory.")]
-    pub tests: String,
-    #[arg(long, default_value=".unitt", help="Path to cache directory.")]
-    pub cache: String,
-    #[arg(long, default_value="**/*.spec.art", help="Glob pattern to match test files.")]
-    pub target: String,
+    // Arguments that can override the default configuration
+    #[arg(long, help="Path to test files directory.")]
+    pub tests: Option<String>,
+    #[arg(long, help="Path to cache directory.")]
+    pub cache: Option<String>,
+    #[arg(long, help="Glob pattern to match test files.")]
+    pub target: Option<String>,
+    #[arg(long, help="Path to the Arturo binary.")]
+    pub arturo: Option<String>,
 
+    // Arguments that control the behavior of the tool
+    #[arg(long, default_value=".", help="Root directory that contains `unitt.toml`.")]
+    pub root: PathBuf,
     #[arg(long, help="Exits on first failure found.")]
     pub fail_fast: bool,
     #[arg(long, help="Suppresses error messages on test failures. Also disables exit code 1 on failure.")]
     pub suppress: bool,
-
-    #[arg(long, default_value="arturo", help="Path to the Arturo binary.")]
-    pub arturo: String,
-
-    #[arg(long, default_value=".", help="Root directory for the tests.")]
-    pub root: PathBuf,
 }
 
-impl Into<Config> for Arguments {
-    fn into(self) -> Config {
+impl Arguments {
+    pub fn merge_with(self, config: Config) -> Config {
         Config {
-            cache: self.cache,
-            tests: self.tests,
-            target: self.target,
-            arturo: self.arturo,
+            cache: self.cache.unwrap_or(config.cache),
+            tests: self.tests.unwrap_or(config.tests),
+            target: self.target.unwrap_or(config.target),
+            arturo: self.arturo.unwrap_or(config.arturo),
             fail_fast: self.fail_fast,
         }
     }

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -36,5 +36,6 @@ pub fn actual_config(args: &cli::Arguments) -> Result<Config, Box<dyn std::error
         cache: args.cache.clone().unwrap_or(config.cache),
         target: args.target.clone().unwrap_or(config.target),
         fail_fast: args.fail_fast,
+        arturo: args.arturo.clone().unwrap_or(config.arturo),
     })
 }

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -1,10 +1,6 @@
-use std::fs;
 use std::path::PathBuf;
 
 use clap::Parser;
-
-use crate::cli;
-use crate::models::config::Config;
 
 #[derive(Parser, Debug)]
 #[command(name = "unitt")]
@@ -12,13 +8,11 @@ use crate::models::config::Config;
 #[command(about = "Lean unit testing tool for Arturo")]
 pub struct Arguments {
     #[arg(long, default_value="specs", help="Path to test files directory.")]
-    pub tests: Option<String>,
-
+    pub tests: String,
     #[arg(long, default_value="unitt", help="Path to cache directory.")]
-    pub cache: Option<String>,
-    
+    pub cache: String,
     #[arg(long, default_value="**/*.spec.art", help="Glob pattern to match test files.")]
-    pub target: Option<String>,
+    pub target: String,
 
     #[arg(long, help="Exits on first failure found.")]
     pub fail_fast: bool,
@@ -26,20 +20,8 @@ pub struct Arguments {
     pub suppress: bool,
 
     #[arg(long, default_value="arturo", help="Path to the Arturo binary.")]
-    pub arturo: Option<String>,
+    pub arturo: String,
 
     #[arg(long, default_value=".", help="Root directory for the tests.")]
     pub root: PathBuf,
-}
-
-pub fn actual_config(args: &cli::Arguments) -> Result<Config, Box<dyn std::error::Error>> {
-    let toml = fs::read_to_string("./unitt.toml")?;
-    let config = Config::from_toml(&toml)?;
-    Ok(Config {
-        tests: args.tests.clone().unwrap_or(config.tests),
-        cache: args.cache.clone().unwrap_or(config.cache),
-        target: args.target.clone().unwrap_or(config.target),
-        fail_fast: args.fail_fast,
-        arturo: args.arturo.clone().unwrap_or(config.arturo),
-    })
 }

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::PathBuf;
 
 use clap::Parser;
 
@@ -26,6 +27,9 @@ pub struct Arguments {
 
     #[arg(long, default_value="arturo", help="Path to the Arturo binary.")]
     pub arturo: Option<String>,
+
+    #[arg(long, default_value=".", help="Root directory for the tests.")]
+    pub root: PathBuf,
 }
 
 pub fn actual_config(args: &cli::Arguments) -> Result<Config, Box<dyn std::error::Error>> {

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -23,6 +23,9 @@ pub struct Arguments {
     pub fail_fast: bool,
     #[arg(long, help="Suppresses error messages on test failures. Also disables exit code 1 on failure.")]
     pub suppress: bool,
+
+    #[arg(long, default_value="arturo", help="Path to the Arturo binary.")]
+    pub arturo: Option<String>,
 }
 
 pub fn actual_config(args: &cli::Arguments) -> Result<Config, Box<dyn std::error::Error>> {

--- a/unitt/src/cli.rs
+++ b/unitt/src/cli.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-#[derive(Parser, Debug)]
+use crate::models::config::Config;
+
+#[derive(Parser, Debug, Clone, PartialEq)]
 #[command(name = "unitt")]
 #[command(version, author="RickBarretto")]
 #[command(about = "Lean unit testing tool for Arturo")]
@@ -24,4 +26,16 @@ pub struct Arguments {
 
     #[arg(long, default_value=".", help="Root directory for the tests.")]
     pub root: PathBuf,
+}
+
+impl Into<Config> for Arguments {
+    fn into(self) -> Config {
+        Config {
+            cache: self.cache,
+            tests: self.tests,
+            target: self.target,
+            arturo: self.arturo,
+            fail_fast: self.fail_fast,
+        }
+    }
 }

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -14,7 +14,7 @@ use models::config::Config;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Arguments::parse();
     let _ = env::set_current_dir(&args.root);
-    let config: Config = dbg!(args.clone().into());
+    let config: Config = args.clone().into();
 
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &config.arturo).await;

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -16,11 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config: Config = args.clone().into();
 
     let _ = env::set_current_dir(&args.root);
-    
-    if !Path::new(&config.arturo).exists() {
-        eprintln!("Arturo binary not found at: {}", config.arturo);
-        std::process::exit(1);
-    }
 
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &config.arturo).await;

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -13,9 +13,8 @@ use models::config::Config;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Arguments::parse();
-    let config: Config = args.clone().into();
-
     let _ = env::set_current_dir(&args.root);
+    let config: Config = dbg!(args.clone().into());
 
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &config.arturo).await;

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -4,7 +4,7 @@ mod display;
 mod models;
 mod runner;
 
-use std::path::PathBuf;
+use std::{env, path::{Path, PathBuf}};
 
 use clap::Parser;
 
@@ -12,10 +12,12 @@ use models::config::Config;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = env::set_current_dir(Path::new(".."))?;
+
     let args = cli::Arguments::parse();
     let config: Config = cli::actual_config(&args)?;
 
-    let arturo = PathBuf::from("./bin/arturo.exe");
+    let arturo = config.arturo.clone();
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &arturo).await;
 

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -4,6 +4,8 @@ mod display;
 mod models;
 mod runner;
 
+use std::{env, path::Path};
+
 use clap::Parser;
 
 use models::config::Config;
@@ -13,6 +15,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Arguments::parse();
     let config: Config = cli::actual_config(&args)?;
     let arturo = config.arturo.clone();
+
+    let _ = env::set_current_dir(args.root);
 
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &arturo).await;

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -4,7 +4,7 @@ mod display;
 mod models;
 mod runner;
 
-use std::{env, path::Path};
+use std::env;
 
 use clap::Parser;
 

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -13,10 +13,9 @@ use models::config::Config;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Arguments::parse();
-    let config: Config = cli::actual_config(&args)?;
-    let arturo = config.arturo.clone();
+    let config: Config = args.clone().into();
 
-    let _ = env::set_current_dir(args.root);
+    let _ = env::set_current_dir(&args.root);
     
     if !Path::new(&config.arturo).exists() {
         eprintln!("Arturo binary not found at: {}", config.arturo);
@@ -24,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     runner::reset_cache(config.cache.clone());
-    runner::generate_tests(&config, &arturo).await;
+    runner::generate_tests(&config, &config.arturo).await;
 
     let tests: Vec<collector::LoadedTest> = collector::load_tests(&config).collect();
     let summary = display::summary_of(&tests);

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -4,20 +4,16 @@ mod display;
 mod models;
 mod runner;
 
-use std::{env, path::{Path, PathBuf}};
-
 use clap::Parser;
 
 use models::config::Config;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let _ = env::set_current_dir(Path::new(".."))?;
-
     let args = cli::Arguments::parse();
     let config: Config = cli::actual_config(&args)?;
-
     let arturo = config.arturo.clone();
+
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &arturo).await;
 

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -17,6 +17,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let arturo = config.arturo.clone();
 
     let _ = env::set_current_dir(args.root);
+    
+    if !Path::new(&config.arturo).exists() {
+        eprintln!("Arturo binary not found at: {}", config.arturo);
+        std::process::exit(1);
+    }
 
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &arturo).await;

--- a/unitt/src/main.rs
+++ b/unitt/src/main.rs
@@ -14,7 +14,8 @@ use models::config::Config;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Arguments::parse();
     let _ = env::set_current_dir(&args.root);
-    let config: Config = args.clone().into();
+    let config: Config = args.clone()
+        .merge_with(Config::from_toml("unitt.toml"));
 
     runner::reset_cache(config.cache.clone());
     runner::generate_tests(&config, &config.arturo).await;

--- a/unitt/src/models/config.rs
+++ b/unitt/src/models/config.rs
@@ -1,34 +1,23 @@
 use serde::Deserialize;
 
-#[derive(Deserialize)]
-struct Proxy {
-    pub cache: Option<String>,
-    pub tests: Option<String>,
-    pub target: Option<String>,
-    pub arturo: Option<String>,
-}
-
-#[derive(PartialEq, Debug)]
-pub struct Config {
+#[derive(Deserialize, Debug, Clone)]
+#[derive(PartialEq)]
+struct Config {
+    #[serde(default)]
     pub cache: String,
+    #[serde(default)]
     pub tests: String,
+    #[serde(default)]
     pub target: String,
-    pub fail_fast: bool,
+    #[serde(default)]
     pub arturo: String,
+    #[serde(default)]
+    pub fail_fast: bool,
 }
 
 impl Config {
-    pub fn from_toml(content: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let proxy: Proxy = toml::from_str(content)?;
-        let default = Config::default();
-
-        Ok(Config {
-            cache: proxy.cache.unwrap_or(default.cache),
-            tests: proxy.tests.unwrap_or(default.tests),
-            target: proxy.target.unwrap_or(default.target),
-            fail_fast: false,
-            arturo: proxy.arturo.unwrap_or(default.arturo),
-        })
+    pub fn from_str(toml_content: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(toml_content)
     }
 }
 
@@ -38,8 +27,8 @@ impl Default for Config {
             cache: ".unitt".into(),
             tests: "specs".into(),
             target: "*.spec.art".into(),
-            fail_fast: false,
             arturo: "arturo".into(),
+            fail_fast: false,
         }
     }
 }
@@ -65,7 +54,7 @@ mod tests {
             arturo = "custom_arturo"
         "#;
 
-        let config: Config = Config::from_toml(toml_content).unwrap();
+        let config: Config = Config::from_str(toml_content).unwrap();
         assert_eq!(config.cache, "custom_cache");
         assert_eq!(config.tests, "custom_tests");
         assert_eq!(config.target, "custom_target");
@@ -78,7 +67,7 @@ mod tests {
             invalid_field; = "value"
         "#;
 
-        let result = Config::from_toml(toml_content);
+        let result = Config::from_str(toml_content);
         assert!(result.is_err());
     }
 
@@ -86,7 +75,7 @@ mod tests {
     fn test_from_toml_str_empty() {
         let toml_content = "";
 
-        let result = Config::from_toml(toml_content).unwrap();
+        let result = Config::from_str(toml_content).unwrap();
         assert_eq!(result, Config::default());
     }
 }

--- a/unitt/src/models/config.rs
+++ b/unitt/src/models/config.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -16,6 +18,23 @@ pub struct Config {
 }
 
 impl Config {
+
+    pub fn from_toml(path: &str) -> Config {
+        match fs::read_to_string(&path) {
+            Ok(content) => match toml::from_str(&content) {
+                Ok(config) => config,
+                Err(e) => {
+                    eprintln!("Error parsing TOML file {}: {}", path, e);
+                    Config::default()
+                }
+            },
+            Err(e) => {
+                eprintln!("Error reading TOML file {}: {}", path, e);
+                Config::default()
+            }
+        }
+    }
+
     pub fn from_str(toml_content: &str) -> Result<Self, toml::de::Error> {
         toml::from_str(toml_content)
     }

--- a/unitt/src/models/config.rs
+++ b/unitt/src/models/config.rs
@@ -5,6 +5,7 @@ struct Proxy {
     pub cache: Option<String>,
     pub tests: Option<String>,
     pub target: Option<String>,
+    pub arturo: Option<String>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -13,6 +14,7 @@ pub struct Config {
     pub tests: String,
     pub target: String,
     pub fail_fast: bool,
+    pub arturo: String,
 }
 
 impl Config {
@@ -24,7 +26,8 @@ impl Config {
             cache: proxy.cache.unwrap_or(default.cache),
             tests: proxy.tests.unwrap_or(default.tests),
             target: proxy.target.unwrap_or(default.target),
-            fail_fast: false
+            fail_fast: false,
+            arturo: proxy.arturo.unwrap_or(default.arturo),
         })
     }
 }
@@ -35,7 +38,8 @@ impl Default for Config {
             cache: ".unitt".into(),
             tests: "specs".into(),
             target: "*.spec.art".into(),
-            fail_fast: false
+            fail_fast: false,
+            arturo: "arturo".into(),
         }
     }
 }
@@ -58,12 +62,14 @@ mod tests {
             cache = "custom_cache"
             tests = "custom_tests"
             target = "custom_target"
+            arturo = "custom_arturo"
         "#;
 
         let config: Config = Config::from_toml(toml_content).unwrap();
         assert_eq!(config.cache, "custom_cache");
         assert_eq!(config.tests, "custom_tests");
         assert_eq!(config.target, "custom_target");
+        assert_eq!(config.arturo, "custom_arturo");
     }
 
     #[test]

--- a/unitt/src/models/config.rs
+++ b/unitt/src/models/config.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
 #[derive(PartialEq)]
-struct Config {
+pub struct Config {
     #[serde(default)]
     pub cache: String,
     #[serde(default)]

--- a/unitt/src/models/config.rs
+++ b/unitt/src/models/config.rs
@@ -21,7 +21,7 @@ impl Config {
 
     pub fn from_toml(path: &str) -> Config {
         match fs::read_to_string(&path) {
-            Ok(content) => match toml::from_str(&content) {
+            Ok(content) => match Self::from_str(&content) {
                 Ok(config) => config,
                 Err(e) => {
                     eprintln!("Error parsing TOML file {}: {}", path, e);

--- a/unitt/src/models/test.rs
+++ b/unitt/src/models/test.rs
@@ -30,11 +30,10 @@ pub struct Test {
     pub assertions: Vec<(String, bool)>,
 }
 
-pub async fn run_test_file(arturo: PathBuf, test_file: PathBuf) -> Result<Output, std::io::Error> {
-    let program = arturo.to_str().unwrap();
+pub async fn run_test_file(arturo: &String, test_file: PathBuf) -> Result<Output, std::io::Error> {
     let file = test_file.to_str().unwrap();
 
-    Command::new(program)
+    Command::new(arturo)
         .arg(file)
         .arg(format!("--filename:{file}"))
         .output()
@@ -54,10 +53,10 @@ mod test {
     async fn should_read_from_generated_file() {
         let _ = env::set_current_dir("..").unwrap();
 
-        let arturo = PathBuf::from("./bin/arturo.exe");
+        let arturo = String::from("./bin/arturo.exe");
         let file = PathBuf::from("specs/simple.spec.art");
 
-        let _ = run_test_file(arturo, file.clone()).await.unwrap();
+        let _ = run_test_file(&arturo, file.clone()).await.unwrap();
         let json_file = format!("{}.json", file.to_str().unwrap());
         let result_file = PathBuf::from(".unitt").join(json_file);
 
@@ -116,9 +115,9 @@ mod test {
     async fn should_execute_arturo() {
         let _ = env::set_current_dir("..").unwrap();
 
-        let arturo = PathBuf::from("./bin/arturo.exe");
+        let arturo = String::from("./bin/arturo.exe");
         let file = PathBuf::from("specs/lib/collections/append.spec.art");
-        let result = run_test_file(arturo, file).await.unwrap();
+        let result = run_test_file(&arturo, file).await.unwrap();
 
         let _ = dbg!(String::from_utf8(result.clone().stdout)
             .unwrap()

--- a/unitt/src/runner.rs
+++ b/unitt/src/runner.rs
@@ -11,7 +11,7 @@ pub fn reset_cache(cache: String) {
     let _ = fs::remove_dir_all(cache);
 }
 
-pub async fn generate_tests(config: &Config, arturo: &PathBuf) {
+pub async fn generate_tests(config: &Config, arturo: &String) {
     let pattern = format!("{}/{}", config.tests, config.target);
     let test_files: Vec<_> = glob(&pattern)
         .expect("Invalid glob pattern")
@@ -22,7 +22,7 @@ pub async fn generate_tests(config: &Config, arturo: &PathBuf) {
     for file in &test_files {
         let (arturo, file) = (arturo.clone(), file.clone());
         join_set.spawn(async move {
-            let result = run_test_file(arturo, file.clone()).await;
+            let result = run_test_file(&arturo, file.clone()).await;
             (file, result)
         });
     }

--- a/unitt/src/runner.rs
+++ b/unitt/src/runner.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::path::PathBuf;
 
 use glob::glob;
 use tokio::task::JoinSet;


### PR DESCRIPTION
This PR adds commands that are suitable for debugging purposes, such as changing the root directory at runtime and also change the arturo's binary path.

The second one is also useful for users which may want to provide support for multiple versions of arturo.